### PR TITLE
Amendments (EGM 2017-11-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # constitution
-Student Robotics Southampton Constitution
+Southampton Competitive Robotics Outreach Constitution

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -22,7 +22,7 @@ The unincorporated association and its property shall be managed by and administ
 \article{Name}
 \label{article:name}
 
-The association's name is ``Southampton Competitive Robotics Outreach'', and hereinafter `the Group'.
+The association's name is ``Southampton Competitive Robotics Outreach'', to be known as ``SCRO'' and hereinafter `the Group'.
 
 % ---------------------------------------------------------
 

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -104,7 +104,7 @@ The objectives of the Group, `the Objects', are:
     \item Chairing:
     \begin{enumerate}
         \item General Meetings shall usually be chaired by the person who has been elected as President.
-        \item If there is no such person or he or she is not present within fifteen minutes of the time appointed for the General Meeting, the Full Members present must elect one of their number to chair.
+        \item If there is no such person or they are not present within fifteen minutes of the time appointed for the General Meeting, the Full Members present must elect one of their number to chair.
     \end{enumerate}
 
     \item Associate Members may speak at General Meetings with the permission of the meeting.
@@ -149,7 +149,7 @@ The objectives of the Group, `the Objects', are:
         \item Treasurer. The Treasurer shall oversee the financing of the Group, set the Group's budget, and maintain the accounts of the Group.
     \end{enumerate}
 
-    \item No one may be appointed a member of the Committee if he or she has been disqualified from becoming a member of the Committee under the provisions of Article \ref{article:disciplinary-action}, `Disciplinary Action'.
+    \item No one may be appointed a member of the Committee if they have been disqualified from becoming a member of the Committee under the provisions of Article \ref{article:disciplinary-action}, `Disciplinary Action'.
     \item The number of the Committee must not be less than three, though is not subject to any maximum. There must always be:
     \begin{enumerate}
         \item a President;
@@ -157,11 +157,11 @@ The objectives of the Group, `the Objects', are:
         \item a Treasurer.
     \end{enumerate}
 
-    \item An officer or ordinary member of the Committee shall cease to hold office if he or she:
+    \item An officer or ordinary member of the Committee shall cease to hold office if they:
     \begin{enumerate}
-        \item ceases to be a Full Member of the Group.
-        \item resigns by notice to the Group, or
-        \item is removed from office by a resolution of the Members in General Meeting or a Meeting of the Committee, in accordance with Article \ref{article:disciplinary-action}, `Disciplinary Action'.
+        \item cease to be a Full Member of the Group.
+        \item resign by notice to the Group, or
+        \item are removed from office by a resolution of the Members in General Meeting or a Meeting of the Committee, in accordance with Article \ref{article:disciplinary-action}, `Disciplinary Action'.
     \end{enumerate}
 \end{enumerate}
 
@@ -249,7 +249,7 @@ The objectives of the Group, `the Objects', are:
 \begin{enumerate}
     \item A Member of the Committee must:
     \begin{enumerate}
-        \item declare the nature and extent of any interest, direct or indirect, which he or she has in any decisions of a Meeting of the Committee or in any transaction or arrangement entered into by the Group which has not been previously declared;
+        \item declare the nature and extent of any interest, direct or indirect, which they have in any decisions of a Meeting of the Committee or in any transaction or arrangement entered into by the Group which has not been previously declared;
         \item absent himself or herself from any discussions of the Committee in which it is possible that a conflict will arise between his or her duty to act solely in the interests of the Group and any personal interest, including but not limited to any personal financial interest.
     \end{enumerate}
 

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -13,18 +13,21 @@
 % =======
 
 \article{Adoption of the Constitution}
+\label{article:adoption-constitution}
 
 The unincorporated association and its property shall be managed by and administered in accordance with this Constitution.
 
 % ---------------------------------------------------------
 
 \article{Name}
+\label{article:name}
 
 The association's name is ``Southampton Competitive Robotics Outreach'', and hereinafter `the Group'.
 
 % ---------------------------------------------------------
 
 \article{Objects}
+\label{article:objects}
 
 The objectives of the Group, `the Objects', are:
 
@@ -45,6 +48,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Membership}
+\label{article:membership}
 
 \begin{enumerate}
     \item Membership is open to natural persons, and is not transferable to anyone else.
@@ -62,13 +66,14 @@ The objectives of the Group, `the Objects', are:
         \item The Member resigns by written notice to the Committee.
         \item Any sum due from the Member to the Group is not paid in full within six months of it falling due.
         \item A Member ceases to be qualified for their category of Membership.
-        \item Membership is revoked by a resolution of the Members in a General Meeting or a Meeting of the Committee, in accordance with Article XIII, `Disciplinary Action'.
+        \item Membership is revoked by a resolution of the Members in a General Meeting or a Meeting of the Committee, in accordance with Article \ref{article:disciplinary-action}, `Disciplinary Action'.
     \end{enumerate}
 \end{enumerate}
 
 % ---------------------------------------------------------
 
 \article{General Meetings}
+\label{article:general-meetings}
 
 \begin{enumerate}
     \item The General Meeting constitute the Group's highest decision ­making body, subject to the provisions of this Constitution.
@@ -78,20 +83,21 @@ The objectives of the Group, `the Objects', are:
     \item The Committee must call an Extraordinary General Meeting if requested to do so in writing by at least five Full Members of the Group.
     \begin{enumerate}
         \item The Members' written request must state a complete agenda for the EGM.
-        \item If the Committee do not hold an EGM within five days of their receipt of the Members' written request, the Members may proceed to hold an EGM in accordance with Article VI, `Proceedings of General Meetings'.
+        \item If the Committee do not hold an EGM within five days of their receipt of the Members' written request, the Members may proceed to hold an EGM in accordance with Article \ref{article:proceedings-general-meetings}, `Proceedings of General Meetings'.
     \end{enumerate}
 \end{enumerate}
 
 % ---------------------------------------------------------
 
 \article{Proceedings of General Meetings}
+\label{article:proceedings-general-meetings}
 
 \begin{enumerate}
     \item Notice:
     \begin{enumerate}
         \item The minimum period of notice required to hold an Annual General Meeting is ten days.  The minimum period of notice required to hold an Extraordinary General Meeting is three days.
         \item The notice must specify the date, time and place of the General Meeting, and an agenda for the General Meeting.
-        \item If the General Meeting is to be an AGM, the notice must say so, and must invite nominations in accordance with Article IX, `Appointment of the Committee'.
+        \item If the General Meeting is to be an AGM, the notice must say so, and must invite nominations in accordance with Article \ref{article:appointment-committee}, `Appointment of the Committee'.
         \item Notice must be given to all Members and to the Committee.
     \end{enumerate}
 
@@ -132,9 +138,10 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Officers and the Committee}
+\label{article:officers-committee}
 
 \begin{enumerate}
-    \item The Group and its property shall be administered and managed by a Committee comprising the officers appointed in accordance with Article IX, `Appointment of the Committee'.
+    \item The Group and its property shall be administered and managed by a Committee comprising the officers appointed in accordance with Article \ref{article:appointment-committee}, `Appointment of the Committee'.
     \item The Group shall have the following officers:
     \begin{enumerate}
         \item President. The President shall oversee the organisation and management of the Group and the Committee as a whole; ensure the officers' accountability to Members, the Committee, and the Students' Union; and represent the Group to all external interests.
@@ -142,7 +149,7 @@ The objectives of the Group, `the Objects', are:
         \item Treasurer. The Treasurer shall oversee the financing of the Group, set the Group's budget, and maintain the accounts of the Group.
     \end{enumerate}
 
-    \item No one may be appointed a member of the Committee if he or she has been disqualified from becoming a member of the Committee under the provisions of Article XIII, `Disciplinary Action'.
+    \item No one may be appointed a member of the Committee if he or she has been disqualified from becoming a member of the Committee under the provisions of Article \ref{article:disciplinary-action}, `Disciplinary Action'.
     \item The number of the Committee must not be less than three, though is not subject to any maximum. There must always be:
     \begin{enumerate}
         \item a President;
@@ -154,13 +161,14 @@ The objectives of the Group, `the Objects', are:
     \begin{enumerate}
         \item ceases to be a Full Member of the Group.
         \item resigns by notice to the Group, or
-        \item is removed from office by a resolution of the Members in General Meeting or a Meeting of the Committee, in accordance with Article XIII, `Disciplinary Action'.
+        \item is removed from office by a resolution of the Members in General Meeting or a Meeting of the Committee, in accordance with Article \ref{article:disciplinary-action}, `Disciplinary Action'.
     \end{enumerate}
 \end{enumerate}
 
 % ---------------------------------------------------------
 
 \article{Meetings of the Committee}
+\label{article:meetings-committee}
 
 \begin{enumerate}
     \item The Committee may regulate their proceedings as they think fit, subject to the provisions of this Article.
@@ -178,6 +186,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Appointment of the Committee}
+\label{article:appointment-committee}
 
 \begin{enumerate}
     \item The Full Members of the Group in General Meeting shall appoint the officers and ordinary members of the Committee by election.
@@ -201,6 +210,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Financial Management}
+\label{article:financial-management}
 
 \begin{enumerate}
     \item The Committee are jointly liable for the proper management of the Group's finances.
@@ -212,6 +222,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Irregularities and Saving Provisions}
+\label{article:irregularities-saving-provisions}
 
 \begin{enumerate}
     \item Subject to sub-clause (b) of this Article, all acts done by a Meeting of the Committee shall be valid notwithstanding the participation in any vote of a member of the Committee:
@@ -221,7 +232,7 @@ The objectives of the Group, `the Objects', are:
         \item who was not entitled to vote on the matter, whether by reason of a conflict of interests or otherwise.
     \end{enumerate}
 
-    \item Sub-clause (a) of this Article does not permit a member of the Committee to keep any benefit that may be conferred upon him or her by a resolution of the Committee if the resolution would otherwise have been void, or if the Committee has not complied with Article XII, `Conflicts of Interests and Conflicts of Loyalties'.
+    \item Sub-clause (a) of this Article does not permit a member of the Committee to keep any benefit that may be conferred upon him or her by a resolution of the Committee if the resolution would otherwise have been void, or if the Committee has not complied with Article \ref{article:conflicts-interest-loyalities}, `Conflicts of Interests and Conflicts of Loyalties'.
     \item The Members in General Meeting may only invalidate, as a Point of Order, a resolution or act of:
     \begin{enumerate}
         \item the Committee;
@@ -233,6 +244,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Conflicts of Interest and Conflicts of Loyalties}
+\label{article:conflicts-interest-loyalities}
 
 \begin{enumerate}
     \item A Member of the Committee must:
@@ -247,12 +259,13 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Disciplinary Action}
+\label{article:disciplinary-action}
 
 \begin{enumerate}
     \item Disciplinary action may be taken against any Member of the Group as a consequence of conduct:
     \begin{enumerate}
         \item detrimental to the reputation of the Group or the Students' Union.
-        \item opposed to the objects of the Group (see Article II) or the Students' Union.
+        \item opposed to the objects of the Group (see Article \ref{article:objects}) or the Students' Union.
         \item in contravention of any provision of this Constitution.
     \end{enumerate}
     \item Disciplinary action that may be taken against any Member may be, but is not limited to:
@@ -279,6 +292,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Affiliation to External Organisations}
+\label{article:affiliation-external-organisations}
 
 \begin{enumerate}
     \item The Group may only become an affiliate of an external organisation if:
@@ -302,6 +316,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Amendment to the Constitution}
+\label{article:amendment-constitution}
 
 \begin{enumerate}
     \item The Group may amend any provision contained in this Constitution provided that:
@@ -325,6 +340,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Dissolution}
+\label{article:dissolution}
 
 \begin{enumerate}
     \item If the Members resolve to dissolve the Group, the Committee will remain in office and be responsible for winding up the affairs of the Group in accordance with this Article.
@@ -346,6 +362,7 @@ The objectives of the Group, `the Objects', are:
 % ---------------------------------------------------------
 
 \article{Interpretation}
+\label{article:interpretation}
 
 In this Constitution:
 \begin{enumerate}
@@ -364,6 +381,7 @@ In this Constitution:
 % ---------------------------------------------------------
 
 \article{Declaration}
+\label{article:declaration}
 
 The Members of the Group in a General Meeting adopted this Constitution:
 

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -56,11 +56,11 @@ The objectives of the Group, `the Objects', are:
     \item Only Full Members are entitled to be elected to the Committee, or to propose, discuss and vote at a General Meeting. These are the sole privileges afforded to the Full Members over any other category of Membership.
     \item The Group may charge a fee for admission to Membership, which may be set by a Meeting of the Committee.
     \item The Committee must keep a register of members (`the register') on the Student Groups Hub provided by the Students' Union at \url{www.susu.org}.
-    \item The Committee may only refuse an application for Membership is, acting reasonably and properly, they consider it to be in the best interests of the Group to refuse the application.
+    \item The Committee may only refuse an application for Membership if, acting reasonably and properly, they consider it to be in the best interests of the Group to refuse the application.
     \item Membership may be terminated if:
     \begin{enumerate}
         \item The Member resigns by written notice to the Committee.
-        \item Any sum due from the Member to the Group is not paid in full within six months of is falling due.
+        \item Any sum due from the Member to the Group is not paid in full within six months of it falling due.
         \item A Member ceases to be qualified for their category of Membership.
         \item Membership is revoked by a resolution of the Members in a General Meeting or a Meeting of the Committee, in accordance with Article XIII, `Disciplinary Action'.
     \end{enumerate}
@@ -194,7 +194,7 @@ The objectives of the Group, `the Objects', are:
         \item A member of the Committee shall retire with effect from the conclusion of the AGM next after his or her appointment, but shall be eligible for re-election at that AGM.
     \end{enumerate}
 
-    \item The Committee must update their committee information on the Student Groups Hub provided by the Students' Union at url{www.susu.org} (or failing that inform the Students' Union's Student Groups Officer) within seven days.  
+    \item The Committee must update their committee information on the Student Groups Hub provided by the Students' Union at \url{www.susu.org} (or failing that inform the Students' Union's Student Groups Officer) within seven days.  
     \item A retiring member of the Committee must transfer all relevant information and documentation to his or her newly-elected counterpart, or to the President, within fourteen days.
 \end{enumerate}
 

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -5,8 +5,8 @@
 % TITLE
 % =====
 
-\title{The Constitution of the Student Robotics (Southampton) Society in the University of Southampton Students' Union}
-\author{Student Robotics (Southampton)}
+\title{The Constitution of the Southampton Competitive Robotics Outreach Society in the University of Southampton Students' Union}
+\author{Southampton Competitive Robotics Outreach}
 \maketitle
 
 % CONTENT
@@ -20,7 +20,7 @@ The unincorporated association and its property shall be managed by and administ
 
 \article{Name}
 
-The association's name is ``Student Robotics (Southampton)'', and hereinafter `the Group'.
+The association's name is ``Southampton Competitive Robotics Outreach'', and hereinafter `the Group'.
 
 % ---------------------------------------------------------
 

--- a/latex/constitution.tex
+++ b/latex/constitution.tex
@@ -34,7 +34,7 @@ The objectives of the Group, `the Objects', are:
     \begin{enumerate}
         \item Teamwork
         \item Planning
-        \item Technical Design 
+        \item Technical Design
         \item Technical Build
         \item Testing
     \end{enumerate}
@@ -107,7 +107,7 @@ The objectives of the Group, `the Objects', are:
     \begin{enumerate}
         \item Every Full Member present at a General Meeting, with the exception of the Chair, shall be entitled to one vote upon every voting matter.  In the case of an equality of votes, the Chair shall have a casting vote.
         \item Decisions may only be made by at least a simple majority of votes at a quorate General Meeting.
-        \item All voting shall be by a show of hands or secret ballot, at the discretion of the Chair. 
+        \item All voting shall be by a show of hands or secret ballot, at the discretion of the Chair.
         \item There shall be no absentee voting.
     \end{enumerate}
 
@@ -119,7 +119,7 @@ The objectives of the Group, `the Objects', are:
 
     \item Reports:
     \begin{enumerate}
-        \item If the General Meeting is an AGM, the Chair may invite any of the Committee to offer a report of their activities whilst in office. 
+        \item If the General Meeting is an AGM, the Chair may invite any of the Committee to offer a report of their activities whilst in office.
         \item The Treasurer must present the Group's accounts to the Members at the AGM.
     \end{enumerate}
 
@@ -142,7 +142,7 @@ The objectives of the Group, `the Objects', are:
         \item Treasurer. The Treasurer shall oversee the financing of the Group, set the Group's budget, and maintain the accounts of the Group.
     \end{enumerate}
 
-\item No one may be appointed a member of the Committee if he or she has been disqualified from becoming a member of the Committee under the provisions of Article XIII, `Disciplinary Action'.
+    \item No one may be appointed a member of the Committee if he or she has been disqualified from becoming a member of the Committee under the provisions of Article XIII, `Disciplinary Action'.
     \item The number of the Committee must not be less than three, though is not subject to any maximum. There must always be:
     \begin{enumerate}
         \item a President;
@@ -188,13 +188,13 @@ The objectives of the Group, `the Objects', are:
     \end{enumerate}
 
     \item The count for elections shall be conducted publicly by the Chair of the General Meeting, who must do so accurately.  Should the Members in General Meeting be dissatisfied with the accuracy of the count, they may resolve as a Point of Order to have the election re-counted or, if they remain dissatisfied, re-run as a by-election.
-    
+
     \item \begin{enumerate}
         \item A member of the Committee shall assume office with effect from the conclusion of the General Meeting of his or her appointment.
         \item A member of the Committee shall retire with effect from the conclusion of the AGM next after his or her appointment, but shall be eligible for re-election at that AGM.
     \end{enumerate}
 
-    \item The Committee must update their committee information on the Student Groups Hub provided by the Students' Union at \url{www.susu.org} (or failing that inform the Students' Union's Student Groups Officer) within seven days.  
+    \item The Committee must update their committee information on the Student Groups Hub provided by the Students' Union at \url{www.susu.org} (or failing that inform the Students' Union's Student Groups Officer) within seven days.
     \item A retiring member of the Committee must transfer all relevant information and documentation to his or her newly-elected counterpart, or to the President, within fourteen days.
 \end{enumerate}
 
@@ -221,7 +221,7 @@ The objectives of the Group, `the Objects', are:
         \item who was not entitled to vote on the matter, whether by reason of a conflict of interests or otherwise.
     \end{enumerate}
 
-\item Sub-clause (a) of this Article does not permit a member of the Committee to keep any benefit that may be conferred upon him or her by a resolution of the Committee if the resolution would otherwise have been void, or if the Committee has not complied with Article XII, `Conflicts of Interests and Conflicts of Loyalties'.
+    \item Sub-clause (a) of this Article does not permit a member of the Committee to keep any benefit that may be conferred upon him or her by a resolution of the Committee if the resolution would otherwise have been void, or if the Committee has not complied with Article XII, `Conflicts of Interests and Conflicts of Loyalties'.
     \item The Members in General Meeting may only invalidate, as a Point of Order, a resolution or act of:
     \begin{enumerate}
         \item the Committee;
@@ -241,7 +241,7 @@ The objectives of the Group, `the Objects', are:
         \item absent himself or herself from any discussions of the Committee in which it is possible that a conflict will arise between his or her duty to act solely in the interests of the Group and any personal interest, including but not limited to any personal financial interest.
     \end{enumerate}
 
-\item Any member of the Committee absenting himself or herself from any discussions in accordance with this Article must not vote or be counted as part of the quorum in any decision of the Committee on the matter.
+    \item Any member of the Committee absenting himself or herself from any discussions in accordance with this Article must not vote or be counted as part of the quorum in any decision of the Committee on the matter.
 \end{enumerate}
 
 % ---------------------------------------------------------
@@ -265,14 +265,14 @@ The objectives of the Group, `the Objects', are:
         \item referral of the complaint to the Students' Union's Disciplinary Committee.
     \end{enumerate}
 
-\item It is the right of the subject of the complaint to choose to have the disciplinary matter heard by either the Members in General Meeting, or a Meeting of the Committee.  Either shall have the power to take disciplinary action, including but not limited to those measures set out in paragraphs (i) - (vi) inclusive in sub-clause (b) of this Article.
+    \item It is the right of the subject of the complaint to choose to have the disciplinary matter heard by either the Members in General Meeting, or a Meeting of the Committee.  Either shall have the power to take disciplinary action, including but not limited to those measures set out in paragraphs (i) - (vi) inclusive in sub-clause (b) of this Article.
 
     \item Any disciplinary hearing must be conducted in an impartial, balanced, and fair manner, considering all representations on the matter.
 
     \item All disciplinary action must be subject to prior discussion with the Students' Union's Student Groups Officer.
 
     \item Members subject to disciplinary action have the right of appeal to the Students' Union's Student Groups Committee.
-    
+
     \item A full report of all disciplinary action taken by the Group in the previous year must be presented at the AGM.
 \end{enumerate}
 
@@ -337,12 +337,12 @@ The objectives of the Group, `the Objects', are:
         \item in such other manner as the Students' Union's Student Groups Committee may approve in writing in advance.
     \end{enumerate}
 
-\item The Members may pass a resolution before or at the same time as the resolution to dissolve the Group specifying the manner in which the Committee are to apply the remaining property or assets of the Group.  The Committee must comply with such a resolution if it is consistent with the provisions of this Article.
+    \item The Members may pass a resolution before or at the same time as the resolution to dissolve the Group specifying the manner in which the Committee are to apply the remaining property or assets of the Group.  The Committee must comply with such a resolution if it is consistent with the provisions of this Article.
     \item In no circumstances shall the net assets of the Group be paid to or distributed among the Members of the Group.
     \item The Committee must ensure the register and all other data held by the Group are securely destroyed upon the dissolution of the Group.
     \item The Committee must notify the Students' Union within seven days that the Group has been dissolved.  If the Committee are obliged to send the Group's accounts to the Students' Union for the accounting period which ended before its dissolution, they must send the Students' Union the Group's final accounts.
 \end{enumerate}
- 
+
 % ---------------------------------------------------------
 
 \article{Interpretation}
@@ -367,9 +367,9 @@ In this Constitution:
 
 The Members of the Group in a General Meeting adopted this Constitution:
 
-Date: 
+Date:
 
-President: 
+President:
 
 Secretary:
 


### PR DESCRIPTION
This pull request details the amendments to the constitution proposed at the 2017-11-20 Extraordinary General Meeting.

Summary:

* Rename the society from "Student Robotics (Southampton)" to "Southampton Competitive Robotics Outreach", also referred to by the acronym "SCRO".
* Replace usages of the phrase "he or she" with the gender-neutral "they".
* Fix a couple of spelling mistakes.
* Minor typographical cleanup, not affecting the wording of the Constitution.